### PR TITLE
Fix GitHub commit author

### DIFF
--- a/app/entities/github_api/discovery.rb
+++ b/app/entities/github_api/discovery.rb
@@ -20,5 +20,7 @@ module GithubApi::Discovery
     edges.each { |edge| block.call(edge["node"]) }
 
     each_commit(username, repository, edges.last["cursor"], &block)
+
+    sleep 3
   end
 end

--- a/app/queries/commits_by_repository_query.rb
+++ b/app/queries/commits_by_repository_query.rb
@@ -4,13 +4,18 @@ CommitsByRepositoryQuery = GithubApi::Client.parse <<-'GRAPHQL'
       defaultBranchRef {
         target {
           ... on Commit {
-            history(first: 5, after: $cursor) {
+            history(first: 100, after: $cursor) {
               edges {
                 cursor
                 node {
                   id
                   message
                   committedDate
+                  author {
+                    user {
+                      login
+                    }
+                  }
                 }
               }
             }

--- a/app/queries/repositories_by_user_query.rb
+++ b/app/queries/repositories_by_user_query.rb
@@ -1,7 +1,7 @@
 RepositoriesByUserQuery = GithubApi::Client.parse <<-'GRAPHQL'
   query($username: String!) {
     user(login: $username) {
-      repositories(first: 50) {
+      repositories(first: 100) {
         edges {
           cursor
           node {

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -14,7 +14,7 @@
   <ul class="commit-listing mt-3">
     <% @commits.sort_by{|commit| commit.votes.sum(:value)}.reverse.each do |commit| %>
       <li>
-        <p><%= commit.message.lines.first %></p>
+        <p><%= commit.message %></p>
         <p><%= commit.user.first_name %> <%= commit.user.last_name %></p>
         <div class="votes-box">
           <div class="votes">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,6 @@ batch.each do |b|
   GetAlumniJob.perform_now(b)
 end
 
-User.all.each do |u|
+User.all.find_each do |u|
   CreateCommitsJob.perform_now(u)
 end


### PR DESCRIPTION
- [x] Répare le fait d'associer le bon auteur à chaque commit.
- [x] Ne garde que la première ligne de chaque message de commit à l'import.
- [x] Rajoute un petit `sleep` entre chaque appel paginé de commits comme sur #20.

Closes #20