### PR TITLE
Show total number of comments 🔢

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -1,6 +1,8 @@
 class CommitsController < ApplicationController
 
   def index
+    @total_count = Commit.count
+
     if params[:query]
       @commits = Commit.joins(:user).where(user: {batch: params[:query]}).by_random.first(100)
     else

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -1,6 +1,5 @@
 <div class="container">
-  <h1><%= @commits.count %> <%= "commit".pluralize(@commits.count) %></h1>
-
+  <h1><%= pluralize @total_count, "commit" %></h1>
 
   <%= form_tag commits_path, method: :get do %>
     <%= text_field_tag :query,


### PR DESCRIPTION
Actuellement on affiche le nombre total de commits de la page :

<img width="361" alt="image" src="https://user-images.githubusercontent.com/132/110208781-68467780-7e89-11eb-8101-fbab66c0d87b.png">

Cette PR change ça pour être le nombre total de commits en tout : 

<img width="282" alt="image" src="https://user-images.githubusercontent.com/132/110208805-90ce7180-7e89-11eb-9a1e-dedfb7e8a2ec.png">
