### PR TITLE
Ignore commit merges when importing commits 🎳

### DIFF
--- a/app/jobs/create_commits_job.rb
+++ b/app/jobs/create_commits_job.rb
@@ -14,8 +14,9 @@ class CreateCommitsJob < ApplicationJob
       next if author.nil?
 
       message = commit["message"].lines.first.strip
-      puts "#{repository.full_name} @#{author_login} “#{message}”"
+      next if message =~ /^Merge/
 
+      puts "#{repository.full_name}: <#{author_login}> #{message}"
       Commit.create!(
         user: author,
         github_id: hash,

--- a/app/jobs/create_commits_job.rb
+++ b/app/jobs/create_commits_job.rb
@@ -6,6 +6,8 @@ class CreateCommitsJob < ApplicationJob
       repository.github_username,
       repository.name
     ) do |commit|
+      next if commit.dig("committer", "email") == "noreply@github.com"
+
       hash = commit["id"]
       next if Commit.where(github_id: hash).any?
 
@@ -14,7 +16,6 @@ class CreateCommitsJob < ApplicationJob
       next if author.nil?
 
       message = commit["message"].lines.first.strip
-      next if message =~ /^Merge/
 
       puts "#{repository.full_name}: <#{author_login}> #{message}"
       Commit.create!(

--- a/app/queries/commits_by_repository_query.rb
+++ b/app/queries/commits_by_repository_query.rb
@@ -16,6 +16,9 @@ CommitsByRepositoryQuery = GithubApi::Client.parse <<-'GRAPHQL'
                       login
                     }
                   }
+                  committer {
+                    email
+                  }
                 }
               }
             }


### PR DESCRIPTION
Pour les futurs imports, ignore les messages qui commencent par `Merge`.