### PR TITLE
Select one batch at a time & counter uses filters 🧪

### DIFF
--- a/app/assets/stylesheets/commits/_index.scss
+++ b/app/assets/stylesheets/commits/_index.scss
@@ -3,11 +3,20 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  .header, .scrollable { padding: .5rem 2rem; }
+  .header {
+    padding: 1rem 2rem 0 2em;
+  }
+  .scrollable {
+    padding: .5rem 2rem;
+  }
   .pagy-bootstrap-nav {
     padding-top: .5rem;
     background-color: $bg-color;
   }
+}
+
+.commits-count {
+  margin-top: .5em;
 }
 
 .commit-listing {

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -1,30 +1,30 @@
 <div class="container commits">
   <div class="header">
-    <h1>
-      <span data-annotate-target="highlight"><%= @total_count %></span>
-      <%= "commit".pluralize(@total_count) %>
-    </h1>
-
     <%=
-      form_tag(
-        commits_path,
+      form_with(
+        url: commits_path,
         method: :get,
         data: { controller: "submit-form" }
-      ) do
+      ) do |f|
     %>
       <%=
-        select_tag(
+        f.select(
           :batch,
-          options_for_select(@batches, params[:batch]),
-          prompt: "Batch number…",
+          @batches.map { |b| ["Batch ##{b}", b] },
+          {
+            selected: params[:batch],
+          },
           data: { action: "change->submit-form#submit" },
         )
       %>
       <%=
-        select_tag(
+        f.select(
           :username,
-          options_for_select(@usernames, params[:username]),
-          prompt: "User…",
+          @users.map { |u| [u.full_name, u.github_username] },
+          {
+            selected: params[:username],
+            include_blank: "All alumni",
+          },
           data: { action: "change->submit-form#submit" },
         )
       %>
@@ -32,6 +32,11 @@
         <%= submit_tag "Search", class: "btn btn-primary" %>
       </noscript>
     <% end %>
+
+    <h1 class="commits-count">
+      <span data-annotate-target="highlight"><%= @pagy.count %></span>
+      <%= "commit".pluralize(@pagy.count) %>
+    </h1>
   </div>
   <div class="scrollable">
     <ul class="commit-listing mt-3">


### PR DESCRIPTION
Changements : 

- Un seul batch à la fois
  - Pas d'option pour voir tous les batchs car ce n'est pas une compétition inter-batchs
  - Affiche par défaut uniquement le dernier batch
  - Renomme les options de "551" en "Batch #551"
  - La liste des utilisateurs est filtrée pour le batch sélectionné, ce qui raccourcit la liste pour le futur

- Le compteur de commits se mets à jour en fonction des filtres de batch et de user
  - Pour refléter se changement, le compteur se trouve en dessous des filtres

Avant
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/132/110790956-f186f100-8271-11eb-94f5-f20944d0f144.png">
Après
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/132/110791275-4f1b3d80-8272-11eb-81b9-e1c953fe8f58.png">

