### PR TITLE
Move default scope from random to top

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -28,6 +28,6 @@ class CommitsController < ApplicationController
   end
 
   def scope
-    Commit::SCOPES.fetch(params[:scope])
+    params[:scope] if Commit::SCOPES.include?(params[:scope])
   end
 end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -3,15 +3,6 @@ class Commit < ApplicationRecord
   belongs_to :repository
   has_many :votes, dependent: :destroy
 
-  scope :top, ->(*) { order(score: :desc) }
-  scope :hot, ->(*) { left_joins(:votes).order(Vote.arel_table[:created_at]) }
-  scope :recent, ->(*) { order(created_at: :desc) }
-  scope :random, ->(*) { by_random }
-
-  scope :voted, ->(session_id) {
-    joins(:votes).where(votes: { session_id: session_id.to_s }).hot
-  }
-
   # Scopes that are publicly available (path => scope name)
   SCOPES = %w[
     top
@@ -20,4 +11,14 @@ class Commit < ApplicationRecord
     recent
     voted
   ]
+
+  scope :top, ->(_session_id) { order(score: :desc) }
+  scope :random, ->(_session_id) { by_random }
+  scope :hot, ->(_session_id) {
+    left_joins(:votes).order(Vote.arel_table[:created_at])
+  }
+  scope :recent, ->(_session_id) { order(created_at: :desc) }
+  scope :voted, ->(session_id) {
+    joins(:votes).where(votes: { session_id: session_id.to_s }).hot
+  }
 end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -13,11 +13,11 @@ class Commit < ApplicationRecord
   }
 
   # Scopes that are publicly available (path => scope name)
-  SCOPES = {
-    'random' => 'random',
-    'top' => 'top',
-    'hot' => 'hot',
-    'recent' => 'recent',
-    'voted' => 'voted'
-  }
+  SCOPES = %w[
+    top
+    random
+    hot
+    recent
+    voted
+  ]
 end

--- a/app/views/commits/_header.html.erb
+++ b/app/views/commits/_header.html.erb
@@ -1,0 +1,57 @@
+<div class="header">
+  <div class="row">
+    <div class="col-sm-auto">
+      <%=
+        form_with(
+          url: scopes_path(Commit::SCOPES.first),
+          method: :get,
+          data: { controller: "submit-form" }
+        ) do |f|
+      %>
+        <%=
+          f.select(
+            :batch,
+            @batches.map { |b| ["Batch ##{b}", b] },
+            {
+              selected: params[:batch],
+            },
+            data: { action: "change->submit-form#submit" },
+          )
+        %>
+        <%=
+          f.select(
+            :username,
+            @users.map { |u| [u.full_name, u.github_username] },
+            {
+              selected: params[:username],
+              include_blank: "All alumni",
+            },
+            data: { action: "change->submit-form#submit" },
+          )
+        %>
+        <noscript>
+          <%= submit_tag "Search", class: "btn btn-primary" %>
+        </noscript>
+      <% end %>
+    </div>
+    <div class="col-sm-auto">
+      <% Commit::SCOPES.each do |scope| %>
+        <%=
+          link_to(
+            scope,
+            scopes_path(scope),
+            class: ('selected' if params[:scope] == scope),
+          )
+        %>
+      <% end %>
+    </div>
+    <div class="col text-sm-right">
+      <p><%= link_to "about", about_path %></p>
+    </div>
+  </div>
+
+  <h1 class="commits-count">
+    <span data-annotate-target="highlight"><%= @pagy.count %></span>
+    <%= "commit".pluralize(@pagy.count) %>
+  </h1>
+</div>

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -1,55 +1,5 @@
 <div class="container commits">
-  <div class="header">
-    <div class="row">
-      <div class="col-sm-auto">
-        <%=
-          form_with(
-            url: scopes_path('random'),
-            method: :get,
-            data: { controller: "submit-form" }
-          ) do |f|
-        %>
-          <%=
-            f.select(
-              :batch,
-              @batches.map { |b| ["Batch ##{b}", b] },
-              {
-                selected: params[:batch],
-              },
-              data: { action: "change->submit-form#submit" },
-            )
-          %>
-          <%=
-            f.select(
-              :username,
-              @users.map { |u| [u.full_name, u.github_username] },
-              {
-                selected: params[:username],
-                include_blank: "All alumni",
-              },
-              data: { action: "change->submit-form#submit" },
-            )
-          %>
-          <noscript>
-            <%= submit_tag "Search", class: "btn btn-primary" %>
-          </noscript>
-        <% end %>
-      </div>
-      <div class="col-sm-auto">
-        <% Commit::SCOPES.keys.each do |path| %>
-          <%= link_to path, path, class: ('selected' if params[:scope] == path) %>
-        <% end %>
-      </div>
-      <div class="col text-sm-right">
-        <p><%= link_to "about", about_path %></p>
-      </div>
-    </div>
-
-    <h1 class="commits-count">
-      <span data-annotate-target="highlight"><%= @pagy.count %></span>
-      <%= "commit".pluralize(@pagy.count) %>
-    </h1>
-  </div>
+  <%= render "commits/header" %>
 
   <div class="scrollable-y custom-scrollbar custom-primary-scrollbar">
     <%= turbo_stream_from "scores" %>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -51,7 +51,7 @@
         <%=
           link_to(
             "‹ Back to the perls",
-            scopes_path("random"),
+            scopes_path(Commit::SCOPES.first),
             class: "btn btn-primary",
           )
         %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <h1>
-    <%= link_to scopes_path('random'), class: "" do %>
+    <%= link_to scopes_path(Commit::SCOPES.first), class: "" do %>
       <%= image_tag("logo.png", alt: "Le Wagon", class: "logo") %>
       <div>
         Prl<span class="animate__animated animate__flash animate__infinite infinite">_</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   get ":scope",
     to: "commits#index",
-    constraints: lambda {|request| Commit::SCOPES.keys.include?(request[:scope])},
+    constraints: -> request { Commit::SCOPES.include?(request[:scope]) },
     as: :scopes
 
   resources :votes, only: :create


### PR DESCRIPTION
Page du top des commits en premier pour mettre plus en avant la feature phare de cette application.

J’en profite pour transformer le hash de scopes en array, pour simplifier un peu, ainsi que d’extraire le menu de haut de page dans une partial.