### PR TITLE
Fix missing scope arguments 🪓

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -12,7 +12,7 @@ class CommitsController < ApplicationController
   private
 
   def filtered_commits
-    commits = Commit.includes(:user).public_send(scope, session.id)
+    commits = Commit.includes(:user).public_send(scope, *scope_arguments)
     commits = commits.where(user: { batch: @batch })
 
     if params[:username].present?
@@ -30,5 +30,9 @@ class CommitsController < ApplicationController
 
   def scope
     params[:scope] if Commit::SCOPES.include?(params[:scope])
+  end
+
+  def scope_arguments
+    [session.id] if scope == "voted"
   end
 end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -12,13 +12,9 @@ class Commit < ApplicationRecord
     voted
   ]
 
-  scope :top, ->(_session_id) { order(score: :desc) }
-  scope :random, ->(_session_id) { by_random }
-  scope :hot, ->(_session_id) {
-    left_joins(:votes).order(Vote.arel_table[:created_at])
-  }
-  scope :recent, ->(_session_id) { order(created_at: :desc) }
-  scope :voted, ->(session_id) {
-    joins(:votes).where(votes: { session_id: session_id.to_s }).hot
-  }
+  scope :top, -> { order(score: :desc) }
+  scope :random, -> { by_random }
+  scope :hot, -> { joins(:votes).order(Vote.arel_table[:created_at].desc) }
+  scope :recent, -> { order(created_at: :desc) }
+  scope :voted, -> session_id { hot.where(votes: { session_id: session_id }) }
 end

--- a/test/models/commit_test.rb
+++ b/test/models/commit_test.rb
@@ -1,7 +1,65 @@
 require "test_helper"
 
 class CommitTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "top scope sorts by score" do
+    repository = Repository.create!(name: "test", github_username: "test")
+    user = User.create!
+    a = Commit.create!(score: 10, repository: repository, user: user)
+    b = Commit.create!(score: 5, repository: repository, user: user)
+    c = Commit.create!(score: 50, repository: repository, user: user)
+
+    assert_equal Commit.top.to_a, [c, a, b]
+  end
+
+  test "random scope sorts by random" do
+    repository = Repository.create!(name: "test", github_username: "test")
+    user = User.create!
+    a = Commit.create!(score: 10, repository: repository, user: user)
+    b = Commit.create!(score: 5, repository: repository, user: user)
+    c = Commit.create!(score: 50, repository: repository, user: user)
+
+    assert_equal Commit.random.sort_by(&:id), [a, b, c]
+  end
+
+  test "hot scope sorts by recent votes first" do
+    repository = Repository.create!(name: "test", github_username: "test")
+    user = User.create!
+    a = Commit.create!(repository: repository, user: user)
+    b = Commit.create!(repository: repository, user: user)
+    c = Commit.create!(repository: repository, user: user)
+
+    Vote.create!(value: 1, commit: c, created_at: 1.day.ago)
+    Vote.create!(value: 1, commit: a, created_at: 2.days.ago)
+
+    assert_equal Commit.hot.to_a, [c, a]
+  end
+
+  test "recent scope sorts by creation date" do
+    repository = Repository.create!(name: "test", github_username: "test")
+    user = User.create!
+    a =
+      Commit.create!(repository: repository, user: user, created_at: 2.days.ago)
+    b =
+      Commit.create!(repository: repository, user: user, created_at: 3.days.ago)
+    c =
+      Commit.create!(repository: repository, user: user, created_at: 1.day.ago)
+
+    assert_equal Commit.recent.to_a, [c, a, b]
+  end
+
+  test "voted scope filters only the current voter" do
+    repository = Repository.create!(name: "test", github_username: "test")
+    user = User.create!
+    a =
+      Commit.create!(repository: repository, user: user, created_at: 2.days.ago)
+    b =
+      Commit.create!(repository: repository, user: user, created_at: 3.days.ago)
+    c =
+      Commit.create!(repository: repository, user: user, created_at: 1.day.ago)
+
+    Vote.create!(value: 1, commit: c, session_id: "42", created_at: 1.day.ago)
+    Vote.create!(value: 1, commit: a, session_id: "42", created_at: 2.days.ago)
+
+    assert_equal Commit.voted("42").to_a, [c, a]
+  end
 end


### PR DESCRIPTION
Répare erreur 500 sur `/voted` introduite dans #58.

Plutôt que de faire en sorte que tous les scopes acceptent toute sorte d'arguments, j'opte pour ne leur passer un argument qu'au scope qui en accepte.

J’en profite pour ajouter des specs sur chaque scope.