### PR TITLE
Replace pagination on random with a “More” link 🎲

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -9,10 +9,17 @@ class CommitsController < ApplicationController
     @session_votes_by_commit_id = session_votes_by_commit_id(@commits)
   end
 
+  protected
+
+  def current_scope
+    params[:scope] if Commit::SCOPES.include?(params[:scope])
+  end
+  helper_method :current_scope
+
   private
 
   def filtered_commits
-    commits = Commit.includes(:user).public_send(scope, session.id)
+    commits = Commit.includes(:user).public_send(current_scope, session.id)
     commits = commits.where(user: { batch: @batch })
 
     if params[:username].present?
@@ -26,9 +33,5 @@ class CommitsController < ApplicationController
     Vote.where(session_id: session.id.to_s).where(commit: commits).to_h do |v|
       [v.commit_id, v]
     end
-  end
-
-  def scope
-    params[:scope] if Commit::SCOPES.include?(params[:scope])
   end
 end

--- a/app/views/commits/_header.html.erb
+++ b/app/views/commits/_header.html.erb
@@ -40,7 +40,7 @@
           link_to(
             scope,
             scopes_path(scope),
-            class: ('selected' if params[:scope] == scope),
+            class: ('selected' if current_scope == scope),
           )
         %>
       <% end %>

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -19,5 +19,15 @@
     </ul>
   </div>
 
-  <%== pagy_bootstrap_nav @pagy if @pagy.pages > 1 %>
+  <% if current_scope == "random" %>
+    <nav class="pagy-bootstrap-nav">
+      <ul class="pagination">
+        <li class="page-item">
+          <%= link_to "More", scopes_path("random"), class: "page-link" %>
+        </li>
+      </ul>
+    </nav>
+  <% else %>
+    <%== pagy_bootstrap_nav @pagy if @pagy.pages > 1 %>
+  <% end %>
 </div>


### PR DESCRIPTION
Sur la page "random", de changer de page n’a pas vraiment de sens car la requête qui génère la seconde page va refaire un random sur tous les commits.

![image](https://user-images.githubusercontent.com/132/132121405-ec832123-a408-4fb9-9f93-4254d089a29a.png)

Je propose donc d’en faire un bouton "plus" qui va juste recharger la page et récupérer de nouveaux commits.

![image](https://user-images.githubusercontent.com/132/132121352-a8c78974-57fd-44b9-8fe7-ddb47f627bae.png)
