### PR TITLE
Use Ruby version from ruby-version file 💎

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.4'
+ruby File.read('.ruby-version').chomp
 
 gem 'rest-client'
 


### PR DESCRIPTION
Mini changement permettant d’éviter de modifier deux fichiers lorsqu’on veut changer de version de Ruby.