### PR TITLE
One step batch adding 🪄

### DIFF
--- a/app/lib/github_api.rb
+++ b/app/lib/github_api.rb
@@ -1,0 +1,2 @@
+module GithubApi
+end

--- a/app/lib/github_api/access_points.rb
+++ b/app/lib/github_api/access_points.rb
@@ -1,0 +1,11 @@
+class GithubApi::AccessPoints
+  def call
+    response = RestClient.get(@url)
+    if response && response.code == 200
+      data = JSON.parse(response.body)
+      return result = OpenStruct.new(success?: true, data: data)
+    else
+      return result = OpenStruct.new(success?: false, result: response)
+    end
+  end
+end

--- a/app/lib/github_api/access_points/user_repositories.rb
+++ b/app/lib/github_api/access_points/user_repositories.rb
@@ -1,0 +1,6 @@
+class GithubApi::AccessPoints::UserRepositories < GithubApi::AccessPoints
+  def initialize(github_username:, **options)
+    @url = "https://api.github.com/users/#{github_username}/repos#{'?' + options.map{"#{_1[0].to_s}=#{_1[1]}"}.join('&') if options.present?}"
+    # https://docs.github.com/en/rest/reference/repos#list-repositories-for-a-user
+  end
+end

--- a/app/lib/kitt.rb
+++ b/app/lib/kitt.rb
@@ -1,0 +1,2 @@
+module Kitt
+end

--- a/app/lib/kitt/access_points.rb
+++ b/app/lib/kitt/access_points.rb
@@ -1,0 +1,13 @@
+class Kitt::AccessPoints
+  def call
+    cookie = ENV.fetch("COOKIE")
+
+    response = RestClient.get(@url, headers = { cookie: cookie })
+    if response && response.code == 200
+      data = JSON.parse(response.body)
+      return result = OpenStruct.new(success?: true, data: data)
+    else
+      return result = OpenStruct.new(success?: false, result: response)
+    end
+  end
+end

--- a/app/lib/kitt/access_points/products.rb
+++ b/app/lib/kitt/access_points/products.rb
@@ -1,0 +1,5 @@
+class Kitt::AccessPoints::Products < Kitt::AccessPoints
+  def initialize(batch_number:)
+    @url = "https://kitt.lewagon.com/api/v1/camps/#{batch_number}/pitch_session"
+  end
+end

--- a/app/lib/kitt/access_points/users.rb
+++ b/app/lib/kitt/access_points/users.rb
@@ -1,0 +1,5 @@
+class Kitt::AccessPoints::Users < Kitt::AccessPoints
+  def initialize(search:)
+    @url = "https://kitt.lewagon.com/api/v1/users?search=#{search}"
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,2 @@
+module GithubService
+end

--- a/app/services/github_service/find_common_repos.rb
+++ b/app/services/github_service/find_common_repos.rb
@@ -1,0 +1,10 @@
+class GithubService::FindCommonRepos
+  def initialize(github_usernames:)
+    @users = github_usernames
+  end
+
+  def call
+    users_repos = @users.map{GithubService::GetListOfReposUrlsForOneUser.new(github_username: _1).call}
+    users_repos[0].intersection(*users_repos[1..-1])
+  end
+end

--- a/app/services/github_service/get_list_of_repos_urls_for_one_user.rb
+++ b/app/services/github_service/get_list_of_repos_urls_for_one_user.rb
@@ -1,0 +1,14 @@
+class GithubService::GetListOfReposUrlsForOneUser
+  def initialize(github_username:)
+    @user = github_username
+  end
+
+  def call
+    repos_request = GithubApi::AccessPoints::UserRepositories.new(github_username: @user, type: 'all').call
+    if repos_request.success?
+      repos_request.data.map{_1.dig('html_url')}
+    else
+      false
+    end
+  end
+end

--- a/app/services/kitt_service.rb
+++ b/app/services/kitt_service.rb
@@ -1,0 +1,2 @@
+module KittService
+end

--- a/app/services/kitt_service/get_batch_product_teams.rb
+++ b/app/services/kitt_service/get_batch_product_teams.rb
@@ -1,0 +1,24 @@
+class KittService::GetBatchProductTeams
+  def initialize(batch_number:)
+    @batch_number = batch_number
+  end
+
+  def call
+    products_page_response = Kitt::AccessPoints::Products.new(batch_number: @batch_number).call
+    if products_page_response.success?
+      parse_and_return_groups_from(products_page_response)
+    else
+      false
+    end
+  end
+
+  def parse_and_return_groups_from(products_page_response)
+    groups = products_page_response.data.dig('team_ready_products').map do |group|
+      OpenStruct.new(
+        id: group.dig('id'),
+        name: group.dig('name'),
+        teammates: group.dig('teammates').unshift(group.dig('product_owner')).map{_1.except('avatar_url')}
+      )
+    end
+  end
+end

--- a/app/services/kitt_service/get_batch_product_teams.rb
+++ b/app/services/kitt_service/get_batch_product_teams.rb
@@ -4,16 +4,16 @@ class KittService::GetBatchProductTeams
   end
 
   def call
-    products_page_response = Kitt::AccessPoints::Products.new(batch_number: @batch_number).call
-    if products_page_response.success?
-      parse_and_return_groups_from(products_page_response)
+    products_page_request = Kitt::AccessPoints::Products.new(batch_number: @batch_number).call
+    if products_page_request.success?
+      parse_and_return_groups_from(products_page_request)
     else
       false
     end
   end
 
-  def parse_and_return_groups_from(products_page_response)
-    groups = products_page_response.data.dig('team_ready_products').map do |group|
+  def parse_and_return_groups_from(products_page_request)
+    groups = products_page_request.data.dig('team_ready_products').map do |group|
       OpenStruct.new(
         id: group.dig('id'),
         name: group.dig('name'),

--- a/app/services/kitt_service/get_user_list_for_a_batch.rb
+++ b/app/services/kitt_service/get_user_list_for_a_batch.rb
@@ -1,0 +1,21 @@
+class KittService::GetUserListForABatch
+  def initialize(batch:)
+    @batch = batch
+  end
+
+  def call
+    users_request = Kitt::AccessPoints::Users.new(search: @batch).call
+    if users_request.success?
+      users = users_request.data.dig('users').map do |user|
+        OpenStruct.new(
+          kitt_id: user.dig('alumnus', 'id'),
+          first_name: user.dig('alumnus', 'first_name'),
+          last_name: user.dig('alumnus', 'last_name'),
+          github_nick: user.dig('alumnus', 'github')
+        )
+      end
+    else
+      false
+    end
+  end
+end

--- a/app/services/kitt_service/get_user_list_for_a_batch.rb
+++ b/app/services/kitt_service/get_user_list_for_a_batch.rb
@@ -1,6 +1,6 @@
 class KittService::GetUserListForABatch
-  def initialize(batch:)
-    @batch = batch
+  def initialize(batch_number:)
+    @batch = batch_number
   end
 
   def call

--- a/app/services/kitt_service/get_user_list_for_a_batch.rb
+++ b/app/services/kitt_service/get_user_list_for_a_batch.rb
@@ -6,14 +6,16 @@ class KittService::GetUserListForABatch
   def call
     users_request = Kitt::AccessPoints::Users.new(search: @batch).call
     if users_request.success?
-      users = users_request.data.dig('users').map do |user|
-        OpenStruct.new(
+      users = {}
+      users_request.data.dig('users').each do |user|
+        users[user.dig('alumnus', 'id')] = OpenStruct.new(
           kitt_id: user.dig('alumnus', 'id'),
           first_name: user.dig('alumnus', 'first_name'),
           last_name: user.dig('alumnus', 'last_name'),
           github_nick: user.dig('alumnus', 'github')
         )
       end
+      users
     else
       false
     end

--- a/app/services/prl_service.rb
+++ b/app/services/prl_service.rb
@@ -1,0 +1,2 @@
+module PrlService
+end

--- a/app/services/prl_service/find_all_group_repos_for_one_batch.rb
+++ b/app/services/prl_service/find_all_group_repos_for_one_batch.rb
@@ -1,0 +1,19 @@
+class PrlService::FindAllGroupReposForOneBatch
+  def initialize(batch_number:)
+    @batch = batch_number
+  end
+
+  def call
+    start_time = Time.now
+    puts 'getting products..'
+    products = KittService::GetBatchProductTeams.new(batch_number: @batch).call
+    puts 'getting alumni..'
+    alumni = KittService::GetUserListForABatch.new(batch_number: @batch).call
+    puts 'getting github nicknames for each alumnus in each group..'
+    github_groups = products.map{_1.teammates.map{|teammate| alumni[teammate['id']].github_nick}}
+    puts 'getting repos for each github user & finding intersections..'
+    github_groups.map{GithubService::FindCommonRepos.new(github_usernames: _1).call}
+    puts "Done in #{(Time.now - start_time).round(2)} seconds (which is painfully slow)"
+    github_groups
+  end
+end

--- a/app/services/prl_service/find_all_group_repos_for_one_batch.rb
+++ b/app/services/prl_service/find_all_group_repos_for_one_batch.rb
@@ -12,8 +12,8 @@ class PrlService::FindAllGroupReposForOneBatch
     puts 'getting github nicknames for each alumnus in each group..'
     github_groups = products.map{_1.teammates.map{|teammate| alumni[teammate['id']].github_nick}}
     puts 'getting repos for each github user & finding intersections..'
-    github_groups.map{GithubService::FindCommonRepos.new(github_usernames: _1).call}
+    group_repos = github_groups.map{GithubService::FindCommonRepos.new(github_usernames: _1).call}
     puts "Done in #{(Time.now - start_time).round(2)} seconds (which is painfully slow)"
-    github_groups
+    group_repos
   end
 end


### PR DESCRIPTION
Petit essai de mise en place de cette logique, pour l'instant sans être relié aux modèles.
L'api de GitHub en non connecté a un limit rate de 60/h pour une même IP, autant dire qu'on peut lancer deux fois le service et après c'est fini pour une heure.

-> PrlService::FindAllGroupReposForOneBatch.new(batch_number: 660).call

je serai ravi d'avoir vos commentaires sur mes tentatives balbutiantes d'organiser ce genre d'interactions avec différentes api/applis externes
