### PR TITLE
Fix GitHub API env name and prefer symbols 🧖‍♂️

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
+
+  # Replace HTTP calls with mocks for testing purposes
+  gem 'webmock'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     devise (4.8.0)
       bcrypt (~> 3.0)
@@ -121,6 +123,7 @@ GEM
       sassc (>= 1.11)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     hashie (5.0.0)
     hotwire-rails (0.1.3)
       rails (>= 6.0.0)
@@ -288,6 +291,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -331,6 +338,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 4.1.0)
   webdrivers
+  webmock
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/app/jobs/create_commits_job.rb
+++ b/app/jobs/create_commits_job.rb
@@ -4,23 +4,23 @@ class CreateCommitsJob < ApplicationJob
   def perform(repository)
     api = Github::Api.new
     api.each_commit(repository.github_username, repository.name) do |commit|
-      next if commit.dig("committer", "email") == "noreply@github.com"
+      next if commit.dig(:committer, :email) == "noreply@github.com"
 
-      hash = commit["id"]
+      hash = commit[:id]
       next if Commit.where(github_id: hash).any?
 
-      author_login = commit.dig("author", "user", "login")
+      author_login = commit.dig(:author, :user, :login)
       author = User.find_by(github_username: author_login)
       next if author.nil?
 
-      message = commit["message"].lines.first.strip
+      message = commit[:message].lines.first.strip
 
       puts "#{repository.full_name}: <#{author_login}> #{message}"
       Commit.create!(
         user: author,
         github_id: hash,
-        message: commit["message"].lines.first,
-        message_date: commit["committedDate"],
+        message: commit[:message].lines.first,
+        message_date: commit[:committedDate],
         repository: repository,
       )
     end

--- a/test/entities/github/api_test.rb
+++ b/test/entities/github/api_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Github::ApiTest < ActiveJob::TestCase
+  test "#each_commit calls GitHub and loops around commits" do
+    api = Github::Api.new
+    username = "testuser"
+    repository = "testrepo"
+
+    mock_commit = {
+      committer: {
+        email: "email@example.com",
+      },
+      id: 1234,
+      author: {
+        user: {
+          login: "someuser",
+        },
+      },
+      message: "some commit message",
+      committedDate: "2018-01-01T00:00:00Z",
+    }
+
+    mock_body_1 = {
+      data: {
+        repository: {
+          defaultBranchRef: {
+            target: {
+              history: {
+                edges: [
+                  {
+                    node: mock_commit,
+                    cursor: "z1",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    }
+
+    mock_body_2 = {
+      data: {
+        repository: {
+          defaultBranchRef: {
+            target: {
+              history: {
+                edges: [],
+              },
+            },
+          },
+        },
+      },
+    }
+
+    expected_request_1_body = {
+      query: Github::Api::COMMITS_BY_REPOSITORY_QUERY,
+      variables: {
+        username: "testuser",
+        repository: "testrepo",
+        cursor: nil,
+      },
+    }
+
+    expected_request_2_body = {
+      query: Github::Api::COMMITS_BY_REPOSITORY_QUERY,
+      variables: {
+        username: "testuser",
+        repository: "testrepo",
+        cursor: "z1",
+      },
+    }
+
+    stub_request(:post, "https://api.github.com/graphql")
+      .with(body: expected_request_1_body.to_json)
+      .to_return(status: 200, body: mock_body_1.to_json)
+
+    stub_request(:post, "https://api.github.com/graphql")
+      .with(body: expected_request_2_body.to_json)
+      .to_return(status: 200, body: mock_body_2.to_json)
+
+    commits = []
+
+    api.each_commit(username, repository) do |commit|
+      commits << commit
+    end
+
+    assert_equal [mock_commit], commits
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative "../config/environment"
 require "rails/test_help"
 
+require "webmock/minitest"
+
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)


### PR DESCRIPTION
Répare appel à l’API GitHub (clef "data" manquante et mauvais nom de variable d’env).

J’en profite pour :
- mieux faire remonter les erreurs
- préférer des symboles à des Strings dans les données