### PR TITLE
Random button stays on the same batch & user 🎲

### DIFF
--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -4,19 +4,21 @@
   <div class="scrollable-y custom-scrollbar custom-primary-scrollbar">
     <%= turbo_stream_from "scores" %>
 
-    <ul class="commit-listing mt-3">
-      <% @commits.each do |commit| %>
-        <%=
-          render(
-            partial: "commits/commit",
-            locals: {
-              commit: commit,
-              vote: @session_votes_by_commit_id[commit.id],
-            }
-          )
-        %>
-      <% end %>
-    </ul>
+    <turbo-frame id="commits">
+      <ul class="commit-listing mt-3">
+        <% @commits.each do |commit| %>
+          <%=
+            render(
+              partial: "commits/commit",
+              locals: {
+                commit: commit,
+                vote: @session_votes_by_commit_id[commit.id],
+              }
+            )
+          %>
+        <% end %>
+      </ul>
+    </turbo-frame>
   </div>
 
   <% if current_scope == "random" %>
@@ -32,6 +34,7 @@
                 username: params[:username],
               ),
               class: "page-link",
+              "data-turbo-frame": "commits",
             )
           %>
         </li>

--- a/app/views/commits/index.html.erb
+++ b/app/views/commits/index.html.erb
@@ -23,7 +23,17 @@
     <nav class="pagy-bootstrap-nav">
       <ul class="pagination">
         <li class="page-item">
-          <%= link_to "More", scopes_path("random"), class: "page-link" %>
+          <%=
+            link_to(
+              "More",
+              scopes_path(
+                "random",
+                batch: current_batch_code,
+                username: params[:username],
+              ),
+              class: "page-link",
+            )
+          %>
         </li>
       </ul>
     </nav>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prl",
   "private": true,
   "dependencies": {
-    "@hotwired/turbo-rails": "^7.0.0-beta.5",
+    "@hotwired/turbo-rails": "^7.1.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,18 +841,18 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@hotwired/turbo-rails@^7.0.0-beta.5":
-  version "7.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.0.0-beta.5.tgz#a0efdb7a20613845c43afe6f376b353e62f7e68d"
-  integrity sha512-zj+ZYbs2IHeJHtLavcLX5K0oW/3K8s3zjok4lpujxqLactp3OpuqBZxKBr+tgODnAX/WYFoKLpzivyx3xVRfTw==
+"@hotwired/turbo-rails@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.1.0.tgz#63df3f0e11aea7c451983266c80ad8896f310952"
+  integrity sha512-eB/PTZQYl7dPm51AfBwm0sBpohJ7eir/JmuOfwJG297lEEA8sFcvpxVON/87Ne97OyAOcORZtLpX0KB+t9afyw==
   dependencies:
-    "@hotwired/turbo" "^7.0.0-beta.4"
-    "@rails/actioncable" "^6.1.0"
+    "@hotwired/turbo" "^7.1.0"
+    "@rails/actioncable" "^6.0.0"
 
-"@hotwired/turbo@^7.0.0-beta.4":
-  version "7.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.0.0-beta.4.tgz#be6d7014902d45121f56358d360e0810bad4c19e"
-  integrity sha512-koox7UeA2Na0tLBPesxNO3nk/gtezRxF33NHKbAx+zv5s2k1Xh/orB5xNr5dAckoUj3Pdpytnw41WH4QB1jYBg==
+"@hotwired/turbo@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.1.0.tgz#27e44e0e3dc5bd1d4bda0766d579cf5a14091cd7"
+  integrity sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA==
 
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
@@ -867,7 +867,7 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
   integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
 
-"@rails/actioncable@^6.0.0", "@rails/actioncable@^6.1.0":
+"@rails/actioncable@^6.0.0":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.3.tgz#c8a67ec4d22ecd6931f7ebd98143fddbc815419a"
   integrity sha512-m02524MR9cTnUNfGz39Lkx9jVvuL0tle4O7YgvouJ7H83FILxzG1nQ5jw8pAjLAr9XQGu+P1sY4SKE3zyhCNjw==


### PR DESCRIPTION
S’assure que le bouton “More" dans la partie "random" reste sur le batch ou alumni que l'on a sélectionné au lieu de revenir sur un filtre vide.

J’en profite également pour faire en sorte de ne pas avoir à recharger toute la page mais que la liste des commits, pour que ça soit un poil plus rapide.